### PR TITLE
Use multipart to send text and HTML emails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=http;AccountName=devst
 
 SMTP_HOST=smtp
 SMTP_PORT=1025
-SMTP_USERNAME=testuser
+SMTP_USERNAME=testuser@example.com
 SMTP_PASSWORD=testpass
 
 # Comma-separated list of Google Group keys (group's email address, group alias, or the unique group ID)

--- a/src/main.py
+++ b/src/main.py
@@ -115,7 +115,7 @@ def sign_up(req: SignUpRequest, request: Request):
             <p>Please confirm your subscription by clicking the button below. This confirmation email will expire in {CODE_TTL_SEC // 60} minutes.</p>
             <a class="confirmation-button" href="{confirmation_url}">Confirm Email</a>
             <p>If the button above does not work, please copy and paste the following URL into your browser:</p>
-            <p class="monospace-text">{confirmation_url}</p>
+            <p class="monospace-text"><pre>{confirmation_url}</pre></p>
             <p> This email was sent to {req.email}. If you did not request this subscription, no further action is required. You won't be subscribed if you don't click the confirmation link.</p>
         </body>
     """

--- a/src/main.py
+++ b/src/main.py
@@ -148,6 +148,7 @@ def sign_up(req: SignUpRequest, request: Request):
                 }}
                 .monospace-text {{
                     font-family: 'Courier New', monospace;
+                    text-decoration: none;
                 }}
             </style>
         </head>

--- a/src/main.py
+++ b/src/main.py
@@ -115,7 +115,7 @@ def sign_up(req: SignUpRequest, request: Request):
             <p>Please confirm your subscription by clicking the button below. This confirmation email will expire in {CODE_TTL_SEC // 60} minutes.</p>
             <a class="confirmation-button" href="{confirmation_url}">Confirm Email</a>
             <p>If the button above does not work, please copy and paste the following URL into your browser:</p>
-            <pre class="monospace-text">{confirmation_url}</pre>
+            <pre class="monospace-text" style="text-decoration: none;">{confirmation_url}</pre>
             <p> This email was sent to {req.email}. If you did not request this subscription, no further action is required. You won't be subscribed if you don't click the confirmation link.</p>
         </body>
     """

--- a/src/main.py
+++ b/src/main.py
@@ -112,7 +112,7 @@ def sign_up(req: SignUpRequest, request: Request):
         <body>
             <h1>Confirm Your Email</h1>
             <p>Please confirm your email address by clicking the button or the link below to receiving updates from "{req.mailing_list}". This confirmation link will expire in {CODE_TTL_SEC // 60} minutes.</p>
-            <a href="{confirmation_url}">Confirm Email</a>
+            <a class="confirmation-button" href="{confirmation_url}">Confirm Email</a>
             <p>If the button above does not work, please copy and paste the following URL into your browser:</p>
             <p class="link-text">{confirmation_url}</p>
             <p>If you did not request this subscription, no further action is required.</p>
@@ -134,7 +134,7 @@ def sign_up(req: SignUpRequest, request: Request):
                     background-color: #f4f4f4;
                     padding: 20px;
                 }}
-                a {{
+                .confirmation-button {{
                     background-color: #007BFF;
                     color: white;
                     padding: 10px 20px;
@@ -142,7 +142,7 @@ def sign_up(req: SignUpRequest, request: Request):
                     border-radius: 5px;
                     font-size: 18px;
                 }}
-                a:hover {{
+                .confirmation-button:hover {{
                     background-color: #0056b3;
                 }}
                 .link-text {{

--- a/src/main.py
+++ b/src/main.py
@@ -115,7 +115,7 @@ def sign_up(req: SignUpRequest, request: Request):
             <p>Please confirm your subscription by clicking the button below. This confirmation email will expire in {CODE_TTL_SEC // 60} minutes.</p>
             <a class="confirmation-button" href="{confirmation_url}">Confirm Email</a>
             <p>If the button above does not work, please copy and paste the following URL into your browser:</p>
-            <pre class="monospace-text" style="text-decoration: none;">{confirmation_url}</pre>
+            <pre class="monospace-text">{confirmation_url}</pre>
             <p> This email was sent to {req.email}. If you did not request this subscription, no further action is required. You won't be subscribed if you don't click the confirmation link.</p>
         </body>
     """
@@ -148,7 +148,6 @@ def sign_up(req: SignUpRequest, request: Request):
                 }}
                 .monospace-text {{
                     font-family: 'Courier New', monospace;
-                    text-decoration: none;
                 }}
             </style>
         </head>

--- a/src/main.py
+++ b/src/main.py
@@ -110,12 +110,13 @@ def sign_up(req: SignUpRequest, request: Request):
 
     msg_html_body = f"""
         <body>
-            <h1>Confirm Your Email</h1>
-            <p>Please confirm your email address by clicking the button or the link below to receiving updates from "{req.mailing_list}". This confirmation link will expire in {CODE_TTL_SEC // 60} minutes.</p>
+            <h1>Confirm Your Subscription</h1>
+            <p>Thanks for signing up for updates from "{req.mailing_list}"!</p>
+            <p>Please confirm your subscription by clicking the button below. This confirmation email will expire in {CODE_TTL_SEC // 60} minutes.</p>
             <a class="confirmation-button" href="{confirmation_url}">Confirm Email</a>
             <p>If the button above does not work, please copy and paste the following URL into your browser:</p>
-            <p class="link-text">{confirmation_url}</p>
-            <p>If you did not request this subscription, no further action is required.</p>
+            <p class="monospace-text">{confirmation_url}</p>
+            <p> This email was sent to {req.email}. If you did not request this subscription, no further action is required. You won't be subscribed if you don't click the confirmation link.</p>
         </body>
     """
     msg_html = f"""
@@ -145,7 +146,7 @@ def sign_up(req: SignUpRequest, request: Request):
                 .confirmation-button:hover {{
                     background-color: #0056b3;
                 }}
-                .link-text {{
+                .monospace-text {{
                     font-family: 'Courier New', monospace;
                 }}
             </style>

--- a/src/main.py
+++ b/src/main.py
@@ -115,7 +115,7 @@ def sign_up(req: SignUpRequest, request: Request):
             <p>Please confirm your subscription by clicking the button below. This confirmation email will expire in {CODE_TTL_SEC // 60} minutes.</p>
             <a class="confirmation-button" href="{confirmation_url}">Confirm Email</a>
             <p>If the button above does not work, please copy and paste the following URL into your browser:</p>
-            <p class="monospace-text"><pre>{confirmation_url}</pre></p>
+            <pre class="monospace-text">{confirmation_url}</pre>
             <p> This email was sent to {req.email}. If you did not request this subscription, no further action is required. You won't be subscribed if you don't click the confirmation link.</p>
         </body>
     """

--- a/src/main.py
+++ b/src/main.py
@@ -19,14 +19,18 @@ from watcloud_utils.logging import logger, set_up_logging
 from google_admin_sdk_utils import DirectoryService
 from utils import get_azure_table_client, random_str
 
+
 class HTMLTextFilter(HTMLParser):
     """
     Converts HTML to plain text.
     Derived from https://stackoverflow.com/a/55825140/4527337
     """
+
     text = ""
+
     def handle_data(self, data):
         self.text += data
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -98,14 +102,11 @@ def sign_up(req: SignUpRequest, request: Request):
 
     # Support both HTML and plain text emails
     # https://stackoverflow.com/a/882770/4527337
-    msg = MIMEMultipart('alternative')
+    msg = MIMEMultipart("alternative")
     msg["Subject"] = f"Confirm Your Email Subscription for '{req.mailing_list}'"
     msg["From"] = os.getenv("SMTP_SEND_AS", os.environ["SMTP_USERNAME"])
     msg["To"] = req.email
     msg["Reply-To"] = os.getenv("SMTP_REPLY_TO", os.environ["SMTP_USERNAME"])
-
-    # msg["MIME-Version"] = "1.0"
-    # msg["Content-Type"] = "text/html; charset=utf-8"
 
     msg_html_body = f"""
         <body>


### PR DESCRIPTION
The message shows up as plain text:

<img width="1552" alt="image" src="https://github.com/user-attachments/assets/06cc2e13-7d7a-4f81-b701-df2173e12c76">

This PR fixes this issue by using MIMEMultipart to send emails.

### Result

outlook
<img width="794" alt="image" src="https://github.com/user-attachments/assets/869b3e32-210c-4b01-a4a2-753d394b586f">

apple mail
<img width="1114" alt="image" src="https://github.com/user-attachments/assets/a09f0074-d309-4cc0-b619-43ee86f5f2cc">


Doesn't look the best in apple mail. But I couldn't immediately see how to fix it. Not a big issue anyway.