### PR TITLE
Use hyphen instead of underscore in api

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -74,7 +74,7 @@ class SignUpRequest(BaseModel):
 CODE_TTL_SEC = 15 * 60
 
 
-@app.post("/sign_up")
+@app.post("/sign-up")
 def sign_up(req: SignUpRequest, request: Request):
     # validate email
     if not re.match(r"[^@]+@[^@]+\.[^@]+", req.email):


### PR DESCRIPTION
It's good practice to use hyphens instead of underscores in URLs: https://stackoverflow.com/a/2318376/4527337