### PR TITLE
Make Google API call in the background

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ apscheduler>=3.10.4,<4
 google-api-python-client>=2.141.0,<3
 google-auth-httplib2>=0.2.0,<1
 google-auth-oauthlib>=1.2.1,<2
+python-slugify>=8.0.4,<9

--- a/src/main.py
+++ b/src/main.py
@@ -34,7 +34,7 @@ class HTMLTextFilter(HTMLParser):
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    scheduler.add_job(cleanup, trigger=CronTrigger.from_crontab("* * * * *"))
+    scheduler.add_job(clean_up, trigger=CronTrigger.from_crontab("* * * * *"))
     scheduler.add_job(commit, trigger=CronTrigger.from_crontab("* * * * *"))
     yield
     scheduler.shutdown()
@@ -214,8 +214,8 @@ def confirm(mailing_list: str, email: str, code: str):
     }
 
 
-@app.post("/cleanup")
-def cleanup():
+@app.post("/clean-up")
+def clean_up():
     """
     Clean up expired signups.
     """
@@ -235,7 +235,7 @@ def cleanup():
 
     app.runtime_info["num_expired_signups"] += deleted_count
     app.runtime_info["last_cleanup_time"] = time.time()
-    msg = f"cleanup: Deleted {deleted_count} expired signup(s)."
+    msg = f"clean_up: Deleted {deleted_count} expired signup(s)."
     logger.info(msg)
     return {"status": "ok", "message": msg}
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,5 +1,8 @@
 import os
+import random
+import string
 
+from slugify import slugify
 from watcloud_utils.logging import logger
 from watcloud_utils.typer import app
 
@@ -42,14 +45,36 @@ def delete_azure_table(table_name: str):
 
 
 @app.command()
-def random_str(length: int = 10):
+def random_str(length: int = 32, chars: str = string.ascii_lowercase):
     """
     Generate a random string of the given length.
-    """
-    import random
-    import string
 
-    return "".join(random.choices(string.ascii_letters, k=length))
+    The default dictionary of characters to choose from is the lowercase alphabet.
+    """
+    return "".join(random.choices(chars, k=length))
+
+@app.command()
+def make_azure_table_key(strs: list[str]):
+    r"""
+    Generate an Azure Table key from the given strings.
+
+    The generated key conforms to the following requirements:
+    - (azure) up to 1024 characters
+    - (azure) does not contain the characters '/', '\', '#', '?', or control characters
+    - (custom) the beginning of each str is guaranteed to be included in the key
+    - (custom) the generated key is deterministic for the given input
+
+    Requirements derived from:
+    - https://learn.microsoft.com/en-us/rest/api/storageservices/understanding-the-table-service-data-model
+    """
+    # Just a naive implementation for now
+    max_len_per_str = 1024 // len(strs)
+
+    key = "".join(slugify(s)[:max_len_per_str] for s in strs)
+
+    return key
+
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently, we execute up to 3 API calls in the `/confirm` endpoint:
1. get entity from azure table
2. create google group membership
3. delete entity from azure table

However, we've been running into `SSLEOF` errors when calling the Google API.

Internal reference: https://watonomous.sentry.io/issues/5728320814/?project=4507799285989376&query=is:unresolved+issue.priority:%5Bhigh,+medium%5D+!namespace:mimir+!namespace:wato-finance-frontend+!namespace:wato-finance-backend&statsPeriod=24h&stream_index=0

<img width="2672" alt="image" src="https://github.com/user-attachments/assets/33e9c6fc-14d0-47d7-ac0a-32d4a10070e0">


According to [this](https://stackoverflow.com/questions/77473865/receiving-ssl-unexpected-eof-error-in-google-cloud-run-when-performing-get-api), it's something to do with not having consistent CPU resources. Without digging into the details, we implement something that is general enough to handle this.

This PR offloads the Google API call to the background. Now, the `/confirm` endpoint simply:
1. Update azure table with a note saying that the entity is confirmed

And we run a background job called `commit` to do the rest:
1. query confirmed entities from azure table
2. create google group memberships
3. delete entities from azure table

The background job is idempotent, so we can retry it when it fails. We keep track of the last successful commit and healthcheck based on it.

During manual testing, if we trigger an exception in the background job loop, it will not interrupt the loop.

This PR changes the RowKey format and is not backwards compatible.

Tested and working in prod. It turns out the local instance of azure tables allows "eq null" (not sure if it works because "ne null" certainly doesn't work) and the cloud one doesn't. It has the error
```
HttpResponseError
One of the request inputs is not valid.
RequestId:5af5611d-e002-0045-48ee-f1c4ed000000
Time:2024-08-19T04:15:00.0135139Z
ErrorCode:InvalidInput
```