### PR TITLE
Retry twice when inserting member into Google Group

### DIFF
--- a/src/google_admin_sdk_utils.py
+++ b/src/google_admin_sdk_utils.py
@@ -36,9 +36,9 @@ class DirectoryService:
     def get_group(self, group_key: str):
         return self.service.groups().get(groupKey=group_key).execute()
 
-    def insert_member(self, group_key: str, email: str):
+    def insert_member(self, group_key: str, email: str, num_retries: int = 2):
         try:
-            self.service.members().insert(groupKey=group_key, body={"email": email}).execute()
+            self.service.members().insert(groupKey=group_key, body={"email": email}).execute(num_retries=num_retries)
         except HttpError as e:
             if e.resp.status == 409:
                 self.logger.warning(f"Member {email} already exists in group {group_key}. Ignoring.")


### PR DESCRIPTION
Docs: https://googleapis.github.io/google-api-python-client/docs/epy/googleapiclient.http.HttpRequest-class.html#execute

We consistently run into SSLEOFError after a period of idling. When manually retrying, the request seems to go through. This PR uses the `num_retries` argument to automatically retry on request failure.